### PR TITLE
Cache deduplication results for statistics reuse

### DIFF
--- a/glue_duplicates_job.py
+++ b/glue_duplicates_job.py
@@ -30,6 +30,7 @@ except ImportError:  # Local / EMR runtime
     getResolvedOptions = None  # type: ignore
     GLUE_RUNTIME = False
 
+from pyspark import StorageLevel  # type: ignore
 from pyspark.sql import DataFrame, Window  # type: ignore
 from pyspark.sql import functions as F  # type: ignore
 
@@ -266,8 +267,9 @@ class DeduplicationProcessor:
         df = self._populate_org_columns(df)
         df = self._assign_stacking_groups(df)
         df = self._compute_stacking_metrics(df)
+        df = df.persist(StorageLevel.MEMORY_AND_DISK)
 
-        stats_df = self._build_statistics(df)
+        stats_df = self._build_statistics(df, cached=True)
         return df, stats_df
 
     # ------------------------------------------------------------------
@@ -622,7 +624,12 @@ class DeduplicationProcessor:
     # Statistics
     # ------------------------------------------------------------------
 
-    def _build_statistics(self, df: DataFrame) -> DataFrame:
+    def _build_statistics(self, df: DataFrame, *, cached: bool = False) -> DataFrame:
+        should_unpersist = False
+        if not cached:
+            df = df.persist(StorageLevel.MEMORY_AND_DISK)
+            should_unpersist = True
+
         total_records = df.count()
         metrics: List[Tuple[str, int, float]] = []
 
@@ -658,7 +665,12 @@ class DeduplicationProcessor:
             count = df.filter(F.col(self.stack_type_col) == stack_value).count()
             metrics.append((label, count, percent(count)))
 
-        return self.spark.createDataFrame(metrics, ["metric", "value", "percentage"])
+        stats_df = self.spark.createDataFrame(metrics, ["metric", "value", "percentage"])
+
+        if should_unpersist:
+            df.unpersist()
+
+        return stats_df
 
 
 # ---------------------------------------------------------------------------
@@ -735,6 +747,9 @@ def main(argv: Optional[List[str]] = None) -> None:
         stats_df.coalesce(1).write.mode("overwrite").option("header", True).csv(
             stats_path
         )
+
+        if processed_df.is_cached:
+            processed_df.unpersist()
     finally:
         if not GLUE_RUNTIME:
             spark.stop()


### PR DESCRIPTION
## Summary
- persist the processed dataframe before statistics are computed so repeated counts use the cached results
- let `_build_statistics` reuse an already cached dataframe while handling its own caching lifecycle when needed
- reuse the cached dataframe for parquet output and clean it up only after both outputs are written

## Testing
- python -m compileall glue_duplicates_job.py

------
https://chatgpt.com/codex/tasks/task_e_68cab59adb208326b03451f061b76948